### PR TITLE
fix: コードベースのバグ修正

### DIFF
--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -178,6 +178,7 @@ export default class GameEngine {
             case "LeftRight":
                 const gen1 = new LeftRightGen();
                 g = gen1.create(canvas, cntNode);
+                break;
             case "Delaunay":
                 const gen2 = new DelaunayPlaneGraphGen();
                 g = gen2.create(canvas, cntNode);

--- a/src/graph/DelaunayPlaneGraphGen.ts
+++ b/src/graph/DelaunayPlaneGraphGen.ts
@@ -55,9 +55,7 @@ export default class DelaunayPlaneGraphGenerator implements PlaneGraphGenerator 
         // 5) エッジをGraphに登録
         for (const key of edgeSet) {
             const [u, v] = key.split(",").map((s) => parseInt(s, 10));
-            console.log(key);
             const e = new GraphEdge(ctx, nodes[u], nodes[v]);
-            console.log(e);
             g.addGraphElement(e);
         }
 

--- a/src/graph/Graph.ts
+++ b/src/graph/Graph.ts
@@ -393,6 +393,7 @@ export class GraphEdge extends Shape {
         const coefNume = (a1y - b2y) * (b1x - b2x) - (a1x - b2x) * (b1y - b2y);
         const coefDeno = (a1y - a2y) * (b1x - b2x) - (a1x - a2x) * (b1y - b2y);
 
+        if (coefDeno === 0) return null;
         const coef = coefNume / coefDeno;
 
         return { y: coef * (a2y - a1y) + a1y, x: coef * (a2x - a1x) + a1x };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,23 +6,22 @@ export const manager = new PageManager(page);
 
 // ページ読み込み時の処理
 document.addEventListener("DOMContentLoaded", () => {
-    if (!window.localStorage) {
-        console.log("localstorage非対応です");
-        manager.goto("title");
-        return;
-    }
-    const dataAdv = window.localStorage.getItem("adv");
-    if (dataAdv) {
-        manager.state.settings.advMode = true;
+    try {
+        const dataAdv = window.localStorage.getItem("adv");
+        if (dataAdv) {
+            manager.state.settings.advMode = true;
 
-        const resultsTimeJson = window.localStorage.getItem("resultsTime");
-        if (resultsTimeJson) manager.loadTimeattackResults(JSON.parse(resultsTimeJson));
-        const resultsArcadeJson = window.localStorage.getItem("resultsArcade")
-        if (resultsArcadeJson) {
-            const datas = JSON.parse(resultsArcadeJson);
-            manager.state.resultsArcade =
-                new ReverseQueue<{ name: string; level: number; timeMs: number }>(datas._queue, datas._size);
+            const resultsTimeJson = window.localStorage.getItem("resultsTime");
+            if (resultsTimeJson) manager.loadTimeattackResults(JSON.parse(resultsTimeJson));
+            const resultsArcadeJson = window.localStorage.getItem("resultsArcade");
+            if (resultsArcadeJson) {
+                const datas = JSON.parse(resultsArcadeJson);
+                manager.state.resultsArcade =
+                    new ReverseQueue<{ name: string; level: number; timeMs: number }>(datas._queue, datas._size);
+            }
         }
+    } catch {
+        console.log("localstorage非対応です");
     }
     manager.goto("title");
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export const manager = new PageManager(page);
 document.addEventListener("DOMContentLoaded", () => {
     if (!window.localStorage) {
         console.log("localstorage非対応です");
+        manager.goto("title");
+        return;
     }
     const dataAdv = window.localStorage.getItem("adv");
     if (dataAdv) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
         manager.state.settings.advMode = true;
 
         const resultsTimeJson = window.localStorage.getItem("resultsTime");
-        if (resultsTimeJson) manager.state.resultsTimeattack = JSON.parse(resultsTimeJson);
+        if (resultsTimeJson) manager.loadTimeattackResults(JSON.parse(resultsTimeJson));
         const resultsArcadeJson = window.localStorage.getItem("resultsArcade")
         if (resultsArcadeJson) {
             const datas = JSON.parse(resultsArcadeJson);

--- a/src/pages/GamePage.ts
+++ b/src/pages/GamePage.ts
@@ -22,9 +22,6 @@ export default class Gamepage extends Page {
      */
     stopwatch?: NeonStopwatch;
 
-    controller: AbortController;
-    signal: AbortSignal;
-
     /* これ以降は定数 */
     /**
      * ゲーム画面描画用のキャンバスのサイズ
@@ -36,8 +33,6 @@ export default class Gamepage extends Page {
 
     constructor(root: HTMLElement) {
         super(root);
-        this.controller = new AbortController();
-        this.signal = this.controller.signal;
     }
 
     /**

--- a/src/pages/PageManager.ts
+++ b/src/pages/PageManager.ts
@@ -3,7 +3,7 @@ import Gamepage from "./GamePage";
 import Resultpage from "./ResultPage";
 import Page from "./Page";
 
-import { Levels, DEFAULT_TIMEATTACK_LEVEL } from "../define";
+import { Levels, LEVELS, DEFAULT_TIMEATTACK_LEVEL } from "../define";
 import { ReverseQueue } from "../util";
 
 type PageLabel = "title" | "game" | "result";
@@ -69,6 +69,14 @@ export default class PageManager {
                 break;
         }
         this.curPage.display();
+    }
+
+    public loadTimeattackResults(data: ResultTimeattack) {
+        this.state.resultsTimeattack = data;
+        for (const level of LEVELS) {
+            const maxId = data[level].reduce((max, r) => Math.max(max, r.id), 0);
+            this.resultNextId[level] = maxId + 1;
+        }
     }
 
     public addTimeattackResult(level: Levels, name: string, totalTimeMs: number, timeMsByRound: number[]) {

--- a/src/pages/ResultPage.ts
+++ b/src/pages/ResultPage.ts
@@ -12,7 +12,8 @@ export default class Resultpage extends Page {
 
     override display(): void {
         const gameMode = manager.state.settings.mode;
-        const latestTimeattackResultTime = manager.state.resultsTimeattack[manager.state.settings.timeattackLevel][Math.min(manager.state.resultsTimeattack[manager.state.settings.timeattackLevel].length - 1, 0)].totalTimeMs;
+        const timeattackResults = manager.state.resultsTimeattack[manager.state.settings.timeattackLevel];
+        const latestTimeattackResultTime = timeattackResults[timeattackResults.length - 1].totalTimeMs;
         const latestArcadeResultTime = manager.state.resultsArcade.front()?.timeMs;
         this.root.innerHTML = `
             <section class="screen-result">


### PR DESCRIPTION
## 概要

コードレビューで発見したバグ・デッドコード・デバッグログを修正しました。

## 修正内容

### Bug 1: LeftRight アルゴリズムが使用不可だった (`GameEngine.ts`)
`switch` 文の `case "LeftRight"` に `break` がなく、常に `case "Delaunay"` へ
フォールスルーしていた。LeftRight アルゴリズムが実質的に選択不可だったため、
`break` を追加して修正。

### Bug 2: 結果画面で常に最初のタイムが表示されていた (`ResultPage.ts`)
`Math.min(length - 1, 0)` は常に `0` 以下を返すため、最新結果ではなく
最初の結果（index 0）が表示されていた。`length - 1` を直接使うよう修正。

### Bug 3: localStorage 非対応環境でクラッシュしていた (`index.ts`)
Safari のプライベートブラウジング等、`window.localStorage` プロパティへの
アクセス自体が `SecurityError` を投げる環境では `if (!window.localStorage)`
のチェックが機能しなかった。localStorage への全アクセスを `try-catch` で囲み、
例外発生時もタイトル画面に遷移するよう修正。

### Bug 4: 平行な辺の交差判定でゼロ除算が発生していた (`Graph.ts`)
辺が平行な場合 `coefDeno === 0` になるが除算前にチェックがなく、NaN 座標が
生成されパーティクル描画が壊れていた。`coefDeno === 0` 時に `null` を返すよう修正。

### Bug 5: advMode 再起動後に最新結果のハイライトが消えていた (`PageManager.ts`, `index.ts`)
localStorage から結果を読み込んだ際に `resultNextId` がリセットされず、
次のゲームの結果が ID=1 で追加されランキングのハイライト判定
(`result.id == results.length`) が常に外れていた。`loadTimeattackResults()` を
追加し、読み込み時に `resultNextId` を各レベルの最大 ID + 1 で再初期化するよう修正。

### Refactor: GamePage の未使用フィールドを削除 (`GamePage.ts`)
`controller` と `signal` が初期化されていたが使用されていない
デッドコードだったため削除。

### Chore: デバッグログを削除 (`DelaunayPlaneGraphGen.ts`)
グラフ生成処理内に残っていたデバッグ用 `console.log` 2行を削除。

## テスト方法

### Bug 2: 結果画面に最新タイムが表示されること
1. `pnpm start` でゲームを起動
2. タイムアタックを1ゲームクリアする（タイム A が記録される）
3. 「もう一度」でもう1ゲームクリアする（タイム B が記録される）
4. 結果画面上部の「タイム:」欄に **タイム B**（直近のプレイ）が表示されることを確認
   - 修正前: 常にタイム A（最初のプレイ）が表示されていた

### Bug 3: localStorage 非対応環境でクラッシュしないこと
1. ~~DevTools コンソールで以下を実行してから F5 でリロード~~
   ```js
   Object.defineProperty(window, 'localStorage', {
     get() { throw new DOMException('SecurityError'); }
   });
   ```
   Chrome(147.0.7727.137)では「設定」＞「プライバシーとセキュリティ」＞「サイトの設定」＞「その他のコンテンツの設定」＞「デバイス上のサイトデータ」＞「デバイスへのデータの保存を許可しない」に該当URLを追加
2. ページがクラッシュせずタイトル画面が表示されることを確認
   - 修正前: SecurityError / TypeError が発生しページが停止していた

### Bug 4: 平行な辺が存在するグラフで描画が壊れないこと
1. ゲームをプレイし、頂点を動かして辺が互いに平行になる配置にする
2. パーティクル（交差点のスパーク）が NaN 座標に飛ばず正常に描画されることを確認
   - 修正前: コンソールに NaN 座標が出力されパーティクルが正常表示されなかった

### Bug 5: advMode リロード後のハイライト
1. タイトル画面で「上級モード」スイッチをオンにする
2. タイムアタックを1ゲームクリアする
3. ページをリロードする（localStorage から結果が読み込まれる）
4. もう1ゲームクリアする
5. 結果ランキング表で 今回プレイした行 が青くハイライトされることを確認
   - 修正前: ハイライトが表示されなかった
  
### 全体
- [ ] pnpm exec tsc --noEmit がエラーなしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)