### PR TITLE
test: vitest 環境を構築しコアロジックのユニットテストを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "jsdom": "^27.0.0",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
+    "vitest": "^3.2.4",
+    "vitest-canvas-mock": "^1.1.4",
     "webpack": "^5.99.8",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,13 +19,19 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       jsdom:
         specifier: ^27.0.0
-        version: 27.0.0(postcss@8.5.6)
+        version: 27.0.0(postcss@8.5.12)
       ts-loader:
         specifier: ^9.5.2
         version: 9.5.4(typescript@5.9.2)(webpack@5.101.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.5.2)(jsdom@27.0.0(postcss@8.5.12))(lightningcss@1.32.0)(terser@5.44.0)
+      vitest-canvas-mock:
+        specifier: ^1.1.4
+        version: 1.1.4(vitest@3.2.4(@types/node@24.5.2)(jsdom@27.0.0(postcss@8.5.12))(lightningcss@1.32.0)(terser@5.44.0))
       webpack:
         specifier: ^5.99.8
         version: 5.101.3(webpack-cli@6.0.1)
@@ -100,6 +106,144 @@ packages:
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
     engines: {node: '>=14.17.0'}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -155,6 +299,131 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -178,11 +447,17 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -240,6 +515,35 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -383,6 +687,10 @@ packages:
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   baseline-browser-mapping@2.8.8:
     resolution: {integrity: sha512-be0PUaPsQX/gPWWgFsdD+GFzaoig5PXaUC1xLkQiYdDnANU8sMnHoQd8JhbJQuvTWrWLyeFN9Imb5Qtfvr4RrQ==}
     hasBin: true
@@ -424,6 +732,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -435,9 +747,17 @@ packages:
   caniuse-lite@1.0.30001745:
     resolution: {integrity: sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -509,6 +829,9 @@ packages:
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
+  cssfontparser@1.2.1:
+    resolution: {integrity: sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==}
+
   cssstyle@5.3.1:
     resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
     engines: {node: '>=20'}
@@ -537,6 +860,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
     engines: {node: '>=18'}
@@ -564,6 +891,10 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -624,6 +955,11 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -647,6 +983,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -657,6 +996,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -675,6 +1018,15 @@ packages:
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -907,6 +1259,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   jsdom@27.0.0:
     resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
     engines: {node: '>=20'}
@@ -929,6 +1284,76 @@ packages:
   launch-editor@2.11.1:
     resolution: {integrity: sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
@@ -937,6 +1362,9 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.2.2:
     resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
     engines: {node: 20 || >=22}
@@ -944,6 +1372,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1000,6 +1431,9 @@ packages:
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  moo-color@1.0.3:
+    resolution: {integrity: sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -1094,6 +1528,13 @@ packages:
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1101,12 +1542,16 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -1184,6 +1629,11 @@ packages:
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -1274,6 +1724,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
 
@@ -1299,6 +1752,9 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -1306,6 +1762,9 @@ packages:
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -1316,6 +1775,9 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1365,6 +1827,28 @@ packages:
 
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.16:
     resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
@@ -1441,6 +1925,75 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest-canvas-mock@1.1.4:
+    resolution: {integrity: sha512-4boWHY+STwAxGl1+uwakNNoQky5EjPLC8HuponXNoAscYyT1h/F7RUvTkl4IyF/MiWr3V8Q626je3Iel3eArqA==}
+    peerDependencies:
+      vitest: ^3.0.0 || ^4.0.0
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -1536,6 +2089,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
@@ -1612,13 +2170,82 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.6)':
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.12)':
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.12
 
   '@csstools/css-tokenizer@3.0.4': {}
 
   '@discoveryjs/json-ext@0.6.3': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1676,6 +2303,81 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -1711,6 +2413,11 @@ snapshots:
     dependencies:
       '@types/node': 24.5.2
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.6
@@ -1719,6 +2426,8 @@ snapshots:
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 24.5.2
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -1792,6 +2501,48 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.5.2
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -1942,6 +2693,8 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
+  assertion-error@2.0.1: {}
+
   baseline-browser-mapping@2.8.8: {}
 
   batch@0.6.1: {}
@@ -1994,6 +2747,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2006,10 +2761,20 @@ snapshots:
 
   caniuse-lite@1.0.30001745: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -2086,10 +2851,12 @@ snapshots:
 
   css.escape@1.5.1: {}
 
-  cssstyle@5.3.1(postcss@8.5.6):
+  cssfontparser@1.2.1: {}
+
+  cssstyle@5.3.1(postcss@8.5.12):
     dependencies:
       '@asamuzakjp/css-color': 4.0.5
-      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.6)
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.12)
       css-tree: 3.1.0
     transitivePeerDependencies:
       - postcss
@@ -2109,6 +2876,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  deep-eql@5.0.2: {}
+
   default-browser-id@5.0.0: {}
 
   default-browser@5.2.1:
@@ -2125,6 +2894,9 @@ snapshots:
   dequal@2.0.3: {}
 
   destroy@1.2.0: {}
+
+  detect-libc@2.1.2:
+    optional: true
 
   detect-node@2.1.0: {}
 
@@ -2169,6 +2941,32 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -2186,11 +2984,17 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
 
   events@3.3.0: {}
+
+  expect-type@1.3.0: {}
 
   express@4.21.2:
     dependencies:
@@ -2237,6 +3041,10 @@ snapshots:
   faye-websocket@0.11.4:
     dependencies:
       websocket-driver: 0.7.4
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fill-range@7.1.1:
     dependencies:
@@ -2455,10 +3263,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@27.0.0(postcss@8.5.6):
+  js-tokens@9.0.1: {}
+
+  jsdom@27.0.0(postcss@8.5.12):
     dependencies:
       '@asamuzakjp/dom-selector': 6.5.6
-      cssstyle: 5.3.1(postcss@8.5.6)
+      cssstyle: 5.3.1(postcss@8.5.12)
       data-urls: 6.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
@@ -2494,15 +3304,71 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+    optional: true
+
   loader-runner@4.3.0: {}
 
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
 
+  loupe@3.2.1: {}
+
   lru-cache@11.2.2: {}
 
   lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -2547,6 +3413,10 @@ snapshots:
   min-indent@1.0.1: {}
 
   minimalistic-assert@1.0.1: {}
+
+  moo-color@1.0.3:
+    dependencies:
+      color-name: 1.1.4
 
   ms@2.0.0: {}
 
@@ -2618,15 +3488,21 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.4: {}
 
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
 
-  postcss@8.5.6:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2712,6 +3588,37 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   retry@0.13.1: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
 
   rrweb-cssom@0.8.0: {}
 
@@ -2830,6 +3737,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
@@ -2868,9 +3777,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  stackback@0.0.2: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  std-env@3.10.0: {}
 
   string_decoder@1.1.1:
     dependencies:
@@ -2883,6 +3796,10 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   supports-color@7.2.0:
     dependencies:
@@ -2919,6 +3836,21 @@ snapshots:
       tslib: 2.8.1
 
   thunky@1.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.16: {}
 
@@ -2980,6 +3912,80 @@ snapshots:
   uuid@8.3.2: {}
 
   vary@1.1.2: {}
+
+  vite-node@3.2.4(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.12
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 24.5.2
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      terser: 5.44.0
+
+  vitest-canvas-mock@1.1.4(vitest@3.2.4(@types/node@24.5.2)(jsdom@27.0.0(postcss@8.5.12))(lightningcss@1.32.0)(terser@5.44.0)):
+    dependencies:
+      cssfontparser: 1.2.1
+      moo-color: 1.0.3
+      vitest: 3.2.4(@types/node@24.5.2)(jsdom@27.0.0(postcss@8.5.12))(lightningcss@1.32.0)(terser@5.44.0)
+
+  vitest@3.2.4(@types/node@24.5.2)(jsdom@27.0.0(postcss@8.5.12))(lightningcss@1.32.0)(terser@5.44.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0)
+      vite-node: 3.2.4(@types/node@24.5.2)(lightningcss@1.32.0)(terser@5.44.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.5.2
+      jsdom: 27.0.0(postcss@8.5.12)
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   w3c-xmlserializer@5.0.0:
     dependencies:
@@ -3129,6 +4135,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wildcard@2.0.1: {}
 

--- a/src/graph/DelaunayPlaneGraphGen.ts
+++ b/src/graph/DelaunayPlaneGraphGen.ts
@@ -65,11 +65,11 @@ export default class DelaunayPlaneGraphGenerator implements PlaneGraphGenerator 
 
 /* =========================== Delaunay実装（Bowyer–Watson） =========================== */
 
-type Point = { x: number; y: number; id: number }; // id >= 0
-type Tri = { a: number; b: number; c: number; ccx: number; ccy: number; ccr2: number }; // 頂点は pts の index
+export type Point = { x: number; y: number; id: number }; // id >= 0
+export type Tri = { a: number; b: number; c: number; ccx: number; ccy: number; ccr2: number }; // 頂点は pts の index
 
 /** メイン：Bowyer–Watson */
-function bowyerWatson(pts: Point[], W: number, H: number): Tri[] {
+export function bowyerWatson(pts: Point[], W: number, H: number): Tri[] {
     // super-triangle を十分大きく作成
     const big = 1e6;
     const pA: Point = { x: -big, y: -big, id: -1 };
@@ -130,7 +130,7 @@ function bowyerWatson(pts: Point[], W: number, H: number): Tri[] {
 }
 
 /** 3点から三角形＋外接円情報を作る（work は先頭に仮想点が入っている点配列） */
-function makeTri(a: number, b: number, c: number, work: Point[]): Tri {
+export function makeTri(a: number, b: number, c: number, work: Point[]): Tri {
     // 反時計回りに整える（安定のため）
     if (!isCCW(work[a], work[b], work[c])) [b, c] = [c, b];
     const { x: ax, y: ay } = work[a];
@@ -157,14 +157,14 @@ function makeTri(a: number, b: number, c: number, work: Point[]): Tri {
 }
 
 /** p が三角形 t の外接円の内部（≒中心からの距離^2 < r^2 + ε）にあるか */
-function inCircumcircle(px: number, py: number, t: Tri): boolean {
+export function inCircumcircle(px: number, py: number, t: Tri): boolean {
     const dx = px - t.ccx;
     const dy = py - t.ccy;
     return dx * dx + dy * dy <= t.ccr2 - 1e-7; // ちょい厳しめ（退化対策）
 }
 
 /** 反時計回り判定 */
-function isCCW(a: Point, b: Point, c: Point): boolean {
+export function isCCW(a: Point, b: Point, c: Point): boolean {
     return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x) > 0;
 }
 
@@ -172,7 +172,7 @@ function isCCW(a: Point, b: Point, c: Point): boolean {
  * 穴の境界を構成する辺だけを取り出す
  * - bad 三角形群の辺を集め、同じ辺が2回現れたものは内部辺として打ち消す
  */
-function uniqueBoundary(edges: Array<{ u: number; v: number }>) {
+export function uniqueBoundary(edges: Array<{ u: number; v: number }>) {
     const key = (u: number, v: number) => (u < v ? `${u},${v}` : `${v},${u}`);
     const map = new Map<string, { u: number; v: number; cnt: number }>();
     for (const e of edges) {

--- a/tests/graph/delaunayUtils.test.ts
+++ b/tests/graph/delaunayUtils.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isCCW,
+    inCircumcircle,
+    uniqueBoundary,
+    makeTri,
+    bowyerWatson,
+    type Point,
+} from '../../src/graph/DelaunayPlaneGraphGen';
+
+function pt(x: number, y: number, id = 0): Point {
+    return { x, y, id };
+}
+
+describe('isCCW', () => {
+    it('反時計回りの三角形は true', () => {
+        expect(isCCW(pt(0, 0), pt(1, 0), pt(0, 1))).toBe(true);
+    });
+
+    it('時計回りの三角形は false', () => {
+        expect(isCCW(pt(0, 0), pt(0, 1), pt(1, 0))).toBe(false);
+    });
+
+    it('直線上の3点（退化）は false', () => {
+        expect(isCCW(pt(0, 0), pt(1, 0), pt(2, 0))).toBe(false);
+    });
+});
+
+describe('inCircumcircle', () => {
+    it('外接円の内部にある点は true', () => {
+        // 正三角形 (0,0),(2,0),(1,√3) → 外接円の中心は (1, 1/√3)
+        const work: Point[] = [pt(0, 0), pt(2, 0), pt(1, Math.sqrt(3))];
+        const tri = makeTri(0, 1, 2, work);
+        expect(inCircumcircle(1, 0.5, tri)).toBe(true);
+    });
+
+    it('外接円の外部にある点は false', () => {
+        const work: Point[] = [pt(0, 0), pt(2, 0), pt(1, Math.sqrt(3))];
+        const tri = makeTri(0, 1, 2, work);
+        expect(inCircumcircle(10, 10, tri)).toBe(false);
+    });
+
+    it('外接円の境界上（1e-7 の余裕で除外）は false', () => {
+        // 直角二等辺三角形 (0,0),(2,0),(0,2) → 外接円の中心は (1,1), 半径 √2
+        const work: Point[] = [pt(0, 0), pt(2, 0), pt(0, 2)];
+        const tri = makeTri(0, 1, 2, work);
+        // 境界点 (2, 2) は中心(1,1) から距離 √2（=r）
+        expect(inCircumcircle(2, 2, tri)).toBe(false);
+    });
+});
+
+describe('uniqueBoundary', () => {
+    it('1つの三角形の3辺はすべて残る', () => {
+        const edges = [
+            { u: 0, v: 1 },
+            { u: 1, v: 2 },
+            { u: 2, v: 0 },
+        ];
+        const result = uniqueBoundary(edges);
+        expect(result).toHaveLength(3);
+    });
+
+    it('2つの三角形が共有する辺は除外される', () => {
+        // 三角形 (0,1,2) と (0,1,3) が辺 0-1 を共有
+        const edges = [
+            { u: 0, v: 1 }, { u: 1, v: 2 }, { u: 2, v: 0 },
+            { u: 0, v: 1 }, { u: 1, v: 3 }, { u: 3, v: 0 },
+        ];
+        const result = uniqueBoundary(edges);
+        expect(result).toHaveLength(4);
+        const keys = result.map(e => [Math.min(e.u, e.v), Math.max(e.u, e.v)].join(','));
+        expect(keys).not.toContain('0,1');
+    });
+
+    it('空配列を渡すと空配列を返す', () => {
+        expect(uniqueBoundary([])).toHaveLength(0);
+    });
+});
+
+describe('makeTri', () => {
+    it('外接円の中心から 3 頂点が等距離（外接円の定義）', () => {
+        const work: Point[] = [pt(0, 0), pt(4, 0), pt(0, 3)];
+        const tri = makeTri(0, 1, 2, work);
+        const d0 = Math.sqrt((0 - tri.ccx) ** 2 + (0 - tri.ccy) ** 2);
+        const d1 = Math.sqrt((4 - tri.ccx) ** 2 + (0 - tri.ccy) ** 2);
+        const d2 = Math.sqrt((0 - tri.ccx) ** 2 + (3 - tri.ccy) ** 2);
+        expect(d0).toBeCloseTo(d1);
+        expect(d1).toBeCloseTo(d2);
+    });
+
+    it('ccr2 が外接円の半径^2 と一致する', () => {
+        const work: Point[] = [pt(0, 0), pt(4, 0), pt(0, 3)];
+        const tri = makeTri(0, 1, 2, work);
+        const r2 = (0 - tri.ccx) ** 2 + (0 - tri.ccy) ** 2;
+        expect(tri.ccr2).toBeCloseTo(r2);
+    });
+});
+
+describe('bowyerWatson', () => {
+    it('3点から三角形を1つ生成する', () => {
+        const pts: Point[] = [pt(0, 0, 0), pt(2, 0, 1), pt(1, 2, 2)];
+        const tris = bowyerWatson(pts, 10, 10);
+        expect(tris).toHaveLength(1);
+    });
+
+    it('4点（正方形）から三角形を2つ生成する', () => {
+        const pts: Point[] = [
+            pt(0, 0, 0), pt(4, 0, 1), pt(4, 4, 2), pt(0, 4, 3),
+        ];
+        const tris = bowyerWatson(pts, 10, 10);
+        expect(tris).toHaveLength(2);
+    });
+
+    it('返却インデックスが [0, n-1] の範囲内', () => {
+        const pts: Point[] = [
+            pt(0, 0, 0), pt(5, 0, 1), pt(5, 5, 2), pt(0, 5, 3), pt(2, 2, 4),
+        ];
+        const tris = bowyerWatson(pts, 10, 10);
+        const n = pts.length;
+        for (const t of tris) {
+            expect(t.a).toBeGreaterThanOrEqual(0);
+            expect(t.a).toBeLessThan(n);
+            expect(t.b).toBeGreaterThanOrEqual(0);
+            expect(t.b).toBeLessThan(n);
+            expect(t.c).toBeGreaterThanOrEqual(0);
+            expect(t.c).toBeLessThan(n);
+        }
+    });
+});

--- a/tests/graph/graph.test.ts
+++ b/tests/graph/graph.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { makeCanvas } from '../helpers/canvas';
+import { Graph, GraphNode, GraphEdge } from '../../src/graph/Graph';
+
+// テスト用グラフ構築ヘルパー
+function makeGraph() {
+    const canvas = makeCanvas();
+    const g = new Graph(canvas);
+    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+    return { g, ctx };
+}
+
+function addNode(g: Graph, ctx: CanvasRenderingContext2D, x: number, y: number, id: number): GraphNode {
+    const n = new GraphNode(ctx, x, y, id);
+    g.addGraphElement(n);
+    return n;
+}
+
+function addEdge(g: Graph, ctx: CanvasRenderingContext2D, n1: GraphNode, n2: GraphNode): GraphEdge {
+    const e = new GraphEdge(ctx, n1, n2);
+    g.addGraphElement(e);
+    return e;
+}
+
+// ボックス形状（4頂点）を持つグラフを返すファクトリ
+//
+//  n0(0,0) ---e01--- n1(4,0)
+//    |                  |
+//   e03               e12
+//    |                  |
+//  n3(0,4) ---e23--- n2(4,4)
+//
+// 対角線 e02: n0-n2 と e13: n1-n3 は交差する
+function makeBoxGraph() {
+    const { g, ctx } = makeGraph();
+    const n0 = addNode(g, ctx, 0, 0, 0);
+    const n1 = addNode(g, ctx, 4, 0, 1);
+    const n2 = addNode(g, ctx, 4, 4, 2);
+    const n3 = addNode(g, ctx, 0, 4, 3);
+    const e01 = addEdge(g, ctx, n0, n1); // 上辺
+    const e12 = addEdge(g, ctx, n1, n2); // 右辺
+    const e23 = addEdge(g, ctx, n2, n3); // 下辺
+    const e03 = addEdge(g, ctx, n0, n3); // 左辺
+    return { g, ctx, n0, n1, n2, n3, e01, e12, e23, e03 };
+}
+
+// ===== culCntCrossedPoint =====
+
+describe('Graph.culCntCrossedPoint', () => {
+    it('辺がないグラフは 0 を返す', () => {
+        const { g } = makeGraph();
+        expect(g.culCntCrossedPoint()).toBe(0);
+    });
+
+    it('非交差の外周4辺は 0 を返す', () => {
+        const { g } = makeBoxGraph();
+        expect(g.culCntCrossedPoint()).toBe(0);
+    });
+
+    it('隣接する辺の交点はカウントしない', () => {
+        // n0-n1-n2 のパス（2辺は n1 を共有）
+        const { g, ctx } = makeGraph();
+        const n0 = addNode(g, ctx, 0, 0, 0);
+        const n1 = addNode(g, ctx, 2, 4, 1);
+        const n2 = addNode(g, ctx, 4, 0, 2);
+        addEdge(g, ctx, n0, n1);
+        addEdge(g, ctx, n1, n2);
+        expect(g.culCntCrossedPoint()).toBe(0);
+    });
+
+    it('交差する2辺は 1 を返す', () => {
+        const { g, ctx } = makeGraph();
+        const n0 = addNode(g, ctx, 0, 0, 0);
+        const n1 = addNode(g, ctx, 4, 4, 1);
+        const n2 = addNode(g, ctx, 4, 0, 2);
+        const n3 = addNode(g, ctx, 0, 4, 3);
+        addEdge(g, ctx, n0, n1); // 対角線 \
+        addEdge(g, ctx, n2, n3); // 対角線 /
+        expect(g.culCntCrossedPoint()).toBe(1);
+    });
+
+    it('交差が2組ある場合は 2 を返す', () => {
+        // 外周4辺 + 対角線2本（2本が交差）
+        const { g, ctx, n0, n1, n2, n3 } = makeBoxGraph();
+        addEdge(g, ctx, n0, n2); // 対角線 \
+        addEdge(g, ctx, n1, n3); // 対角線 /（上と交差）
+        expect(g.culCntCrossedPoint()).toBe(1);
+    });
+});
+
+// ===== checkCrossedGraph =====
+
+describe('Graph.checkCrossedGraph', () => {
+    it('辺がないグラフは false を返す', () => {
+        const { g } = makeGraph();
+        expect(g.checkCrossedGraph()).toBe(false);
+    });
+
+    it('交差のないグラフは false を返す', () => {
+        const { g } = makeBoxGraph();
+        expect(g.checkCrossedGraph()).toBe(false);
+    });
+
+    it('交差が1つでもあれば true を返す', () => {
+        const { g, ctx } = makeGraph();
+        const n0 = addNode(g, ctx, 0, 0, 0);
+        const n1 = addNode(g, ctx, 4, 4, 1);
+        const n2 = addNode(g, ctx, 4, 0, 2);
+        const n3 = addNode(g, ctx, 0, 4, 3);
+        addEdge(g, ctx, n0, n1);
+        addEdge(g, ctx, n2, n3);
+        expect(g.checkCrossedGraph()).toBe(true);
+    });
+});
+
+// ===== updateEdgeStatus =====
+
+describe('Graph.updateEdgeStatus', () => {
+    it('交差しない辺はすべて "normal" のまま', () => {
+        const { g, e01, e12, e23, e03 } = makeBoxGraph();
+        g.updateEdgeStatus();
+        expect(e01.status).toBe('normal');
+        expect(e12.status).toBe('normal');
+        expect(e23.status).toBe('normal');
+        expect(e03.status).toBe('normal');
+    });
+
+    it('交差する辺は "alert" になり、非交差辺は "normal" のまま', () => {
+        const { g, ctx, n0, n1, n2, n3, e01, e12, e23, e03 } = makeBoxGraph();
+        const eDiag1 = addEdge(g, ctx, n0, n2); // 対角線 \
+        const eDiag2 = addEdge(g, ctx, n1, n3); // 対角線 /
+        g.updateEdgeStatus();
+        expect(eDiag1.status).toBe('alert');
+        expect(eDiag2.status).toBe('alert');
+        // 外周辺は交差していない
+        expect(e01.status).toBe('normal');
+        expect(e12.status).toBe('normal');
+        expect(e23.status).toBe('normal');
+        expect(e03.status).toBe('normal');
+    });
+
+    it('交差が解消されると "normal" に戻る', () => {
+        const { g, ctx } = makeGraph();
+        const n0 = addNode(g, ctx, 0, 0, 0);
+        const n1 = addNode(g, ctx, 4, 4, 1);
+        const n2 = addNode(g, ctx, 4, 0, 2);
+        const n3 = addNode(g, ctx, 0, 4, 3);
+        const e1 = addEdge(g, ctx, n0, n1);
+        const e2 = addEdge(g, ctx, n2, n3);
+
+        g.updateEdgeStatus();
+        expect(e1.status).toBe('alert');
+
+        // n3 を動かして交差を解消
+        n3.setPos(5, 5);
+        g.updateEdgeStatus();
+        expect(e1.status).toBe('normal');
+        expect(e2.status).toBe('normal');
+    });
+});
+
+// ===== getClosestNode =====
+
+describe('Graph.getClosestNode', () => {
+    it('ノードがないグラフは null を返す', () => {
+        const { g } = makeGraph();
+        expect(g.getClosestNode(0, 0)).toBeNull();
+    });
+
+    it('ノードが1つの場合そのノードを返す', () => {
+        const { g, ctx } = makeGraph();
+        const n = addNode(g, ctx, 10, 20, 0);
+        expect(g.getClosestNode(0, 0)).toBe(n);
+    });
+
+    it('複数ノードの中から最近傍を返す', () => {
+        const { g, ctx } = makeGraph();
+        const near = addNode(g, ctx, 1, 1, 0);
+        addNode(g, ctx, 10, 10, 1);
+        addNode(g, ctx, 20, 20, 2);
+        expect(g.getClosestNode(0, 0)).toBe(near);
+    });
+
+    it('クエリ座標がノード上にある場合そのノードを返す', () => {
+        const { g, ctx } = makeGraph();
+        addNode(g, ctx, 5, 5, 0);
+        const exact = addNode(g, ctx, 3, 3, 1);
+        addNode(g, ctx, 8, 8, 2);
+        expect(g.getClosestNode(3, 3)).toBe(exact);
+    });
+});

--- a/tests/graph/graphEdge.test.ts
+++ b/tests/graph/graphEdge.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { GraphEdge, GraphNode } from '../../src/graph/Graph';
+
+// checkCrossed 用：getPos() だけ必要なのでスタブノードを使う
+function edge(x1: number, y1: number, x2: number, y2: number): GraphEdge {
+    const n1 = { getPos: (): [number, number] => [x1, y1] } as unknown as GraphNode;
+    const n2 = { getPos: (): [number, number] => [x2, y2] } as unknown as GraphNode;
+    return new GraphEdge({} as unknown as CanvasRenderingContext2D, n1, n2);
+}
+
+describe('GraphEdge.checkCrossed', () => {
+    it('X 字交差で交点を返す', () => {
+        const ab = edge(0, 0, 2, 2);
+        const cd = edge(0, 2, 2, 0);
+        const result = ab.checkCrossed(cd);
+        expect(result).not.toBeNull();
+        expect(result!.x).toBeCloseTo(1);
+        expect(result!.y).toBeCloseTo(1);
+    });
+
+    it('平行な水平線分は null', () => {
+        const ab = edge(0, 0, 4, 0);
+        const cd = edge(0, 1, 4, 1);
+        expect(ab.checkCrossed(cd)).toBeNull();
+    });
+
+    it('同一直線上で重なる線分（coefDeno=0）は null', () => {
+        const ab = edge(0, 0, 4, 0);
+        const cd = edge(2, 0, 6, 0);
+        expect(ab.checkCrossed(cd)).toBeNull();
+    });
+
+    it('延長線上で交わるが線分としては交差しない', () => {
+        const ab = edge(0, 0, 1, 0);
+        const cd = edge(3, -1, 3, 1);
+        expect(ab.checkCrossed(cd)).toBeNull();
+    });
+
+    it('端点が相手線分の途中にある境界ケース', () => {
+        // cd の始点 (1,0) が ab の上にある
+        const ab = edge(0, 0, 2, 0);
+        const cd = edge(1, 0, 1, 2);
+        const result = ab.checkCrossed(cd);
+        expect(result).not.toBeNull();
+        expect(result!.x).toBeCloseTo(1);
+        expect(result!.y).toBeCloseTo(0);
+    });
+
+    it('非軸平行な斜め交差', () => {
+        // (0,0)-(4,2) と (0,2)-(4,0) が (2,1) で交差
+        const ab = edge(0, 0, 4, 2);
+        const cd = edge(0, 2, 4, 0);
+        const result = ab.checkCrossed(cd);
+        expect(result).not.toBeNull();
+        expect(result!.x).toBeCloseTo(2);
+        expect(result!.y).toBeCloseTo(1);
+    });
+
+    it('端点同士が一致する場合は交点として返す', () => {
+        // ab の終点 (2,0) と cd の始点 (2,0) が同じ座標（別ノード）
+        // s1*t1=0, s2*t2=0 のため null 条件を通過し、交点を返す
+        const ab = edge(0, 0, 2, 0);
+        const cd = edge(2, 0, 2, 2);
+        const result = ab.checkCrossed(cd);
+        expect(result).not.toBeNull();
+        expect(result!.x).toBeCloseTo(2);
+        expect(result!.y).toBeCloseTo(0);
+    });
+
+    it('垂直線分と水平線分の T 字（端点が線分の中間）', () => {
+        // ab: (0,0)-(4,0) の中点 (2,0) に cd が刺さる
+        const ab = edge(0, 0, 4, 0);
+        const cd = edge(2, 0, 2, 4);
+        const result = ab.checkCrossed(cd);
+        expect(result).not.toBeNull();
+        expect(result!.x).toBeCloseTo(2);
+        expect(result!.y).toBeCloseTo(0);
+    });
+
+    it('対称性：ab.checkCrossed(cd) と cd.checkCrossed(ab) が同一点', () => {
+        const ab = edge(0, 0, 2, 2);
+        const cd = edge(0, 2, 2, 0);
+        const r1 = ab.checkCrossed(cd);
+        const r2 = cd.checkCrossed(ab);
+        expect(r1).not.toBeNull();
+        expect(r2).not.toBeNull();
+        expect(r1!.x).toBeCloseTo(r2!.x);
+        expect(r1!.y).toBeCloseTo(r2!.y);
+    });
+});
+
+describe('GraphEdge.checkNeighbor', () => {
+    // checkNeighbor は参照の同一性で判定するため、実際の GraphNode インスタンスを共有する
+    // GraphNode のコンストラクタは canvas を必要とするが、ここでは直接使用せず
+    // 単純な object + 型キャストで代替する
+    function makeNode(): GraphNode {
+        return { getPos: (): [number, number] => [0, 0] } as unknown as GraphNode;
+    }
+
+    it('始点ノードを共有する場合 true', () => {
+        const ctx = {} as unknown as CanvasRenderingContext2D;
+        const n1 = makeNode();
+        const n2 = makeNode();
+        const n3 = makeNode();
+        const ab = new GraphEdge(ctx, n1, n2);
+        const ac = new GraphEdge(ctx, n1, n3);
+        expect(ab.checkNeighbor(ac)).toBe(true);
+    });
+
+    it('終点ノードを共有する場合 true', () => {
+        const ctx = {} as unknown as CanvasRenderingContext2D;
+        const n1 = makeNode();
+        const n2 = makeNode();
+        const n3 = makeNode();
+        const ab = new GraphEdge(ctx, n1, n2);
+        const cb = new GraphEdge(ctx, n3, n2);
+        expect(ab.checkNeighbor(cb)).toBe(true);
+    });
+
+    it('完全に別ノードの辺は false', () => {
+        const ctx = {} as unknown as CanvasRenderingContext2D;
+        const n1 = makeNode();
+        const n2 = makeNode();
+        const n3 = makeNode();
+        const n4 = makeNode();
+        const ab = new GraphEdge(ctx, n1, n2);
+        const cd = new GraphEdge(ctx, n3, n4);
+        expect(ab.checkNeighbor(cd)).toBe(false);
+    });
+});

--- a/tests/graph/graphNode.test.ts
+++ b/tests/graph/graphNode.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { makeCtx } from '../helpers/canvas';
+import { GraphNode } from '../../src/graph/Graph';
+
+describe('GraphNode', () => {
+    it('コンストラクタが canvas モック環境でエラーなく完了する', () => {
+        const ctx = makeCtx();
+        expect(() => new GraphNode(ctx, 100, 200, 0)).not.toThrow();
+    });
+
+    it('getDist(cx, cy) が 0 を返す', () => {
+        const ctx = makeCtx();
+        const node = new GraphNode(ctx, 100, 200, 0);
+        expect(node.getDist(100, 200)).toBe(0);
+    });
+
+    it('getDist が 3-4-5 直角三角形で 5 を返す', () => {
+        const ctx = makeCtx();
+        const node = new GraphNode(ctx, 0, 0, 0);
+        expect(node.getDist(3, 4)).toBeCloseTo(5);
+    });
+
+    it('getDist が負のオフセットでも正の距離を返す', () => {
+        const ctx = makeCtx();
+        const node = new GraphNode(ctx, 0, 0, 0);
+        expect(node.getDist(-3, -4)).toBeCloseTo(5);
+    });
+
+    it('getPos がコンストラクタに渡した座標を返す', () => {
+        const ctx = makeCtx();
+        const node = new GraphNode(ctx, 150, 250, 1);
+        expect(node.getPos()).toEqual([150, 250]);
+    });
+
+    it('setPos 後に getDist が新座標基準で計算される', () => {
+        const ctx = makeCtx();
+        const node = new GraphNode(ctx, 0, 0, 0);
+        node.setPos(10, 10);
+        expect(node.getDist(10, 10)).toBe(0);
+        expect(node.getDist(13, 14)).toBeCloseTo(5);
+    });
+});

--- a/tests/helpers/canvas.ts
+++ b/tests/helpers/canvas.ts
@@ -1,0 +1,13 @@
+export function makeCtx(): CanvasRenderingContext2D {
+    const c = document.createElement('canvas');
+    c.width = 500;
+    c.height = 500;
+    return c.getContext('2d') as CanvasRenderingContext2D;
+}
+
+export function makeCanvas(w = 500, h = 500): HTMLCanvasElement {
+    const c = document.createElement('canvas');
+    c.width = w;
+    c.height = h;
+    return c;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,2 @@
+import 'vitest-canvas-mock';
+import '@testing-library/jest-dom/vitest';

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { ReverseQueue } from '../src/util';
+
+describe('ReverseQueue', () => {
+    it('push は先頭（最新順）に挿入される', () => {
+        const q = new ReverseQueue<number>();
+        q.push(1);
+        q.push(2);
+        q.push(3);
+        expect(q.range()).toEqual([3, 2, 1]);
+    });
+
+    it('size を超えたら末尾（最古）が脱落する', () => {
+        const q = new ReverseQueue<number>([], 3);
+        q.push(1);
+        q.push(2);
+        q.push(3);
+        q.push(4);
+        expect(q.length()).toBe(3);
+        expect(q.range()).toEqual([4, 3, 2]);
+    });
+
+    it('pop が末尾（最古）を除去する', () => {
+        const q = new ReverseQueue<number>();
+        q.push(1);
+        q.push(2);
+        q.push(3);
+        q.pop();
+        expect(q.range()).toEqual([3, 2]);
+    });
+
+    it('length が push/pop を正確に追跡する', () => {
+        const q = new ReverseQueue<number>();
+        expect(q.length()).toBe(0);
+        q.push(10);
+        expect(q.length()).toBe(1);
+        q.push(20);
+        expect(q.length()).toBe(2);
+        q.pop();
+        expect(q.length()).toBe(1);
+    });
+
+    it('front が先頭要素を返す', () => {
+        const q = new ReverseQueue<string>();
+        q.push('a');
+        q.push('b');
+        expect(q.front()).toBe('b');
+    });
+
+    it('front が空キューで undefined を返す', () => {
+        const q = new ReverseQueue<number>();
+        expect(q.front()).toBeUndefined();
+    });
+
+    it('range が内部状態を汚染しないコピーを返す', () => {
+        const q = new ReverseQueue<number>();
+        q.push(1);
+        q.push(2);
+        const snapshot = q.range() as number[];
+        snapshot.splice(0, 1);
+        expect(q.length()).toBe(2);
+        expect(q.range()).toEqual([2, 1]);
+    });
+
+    it('初期値ありコンストラクタで構築できる', () => {
+        const q = new ReverseQueue<number>([10, 20, 30]);
+        expect(q.length()).toBe(3);
+        expect(q.range()).toEqual([10, 20, 30]);
+    });
+
+    it('size なしの場合は上限なし', () => {
+        const q = new ReverseQueue<number>();
+        for (let i = 0; i < 100; i++) q.push(i);
+        expect(q.length()).toBe(100);
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./tests/setup.ts'],
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- vitest / vitest-canvas-mock を devDependencies に追加し、テスト基盤を整備した
- ゲームの根幹ロジックを中心に 5 ファイル・56 テストケースを追加
- `DelaunayPlaneGraphGen.ts` のモジュールプライベートなヘルパー関数をエクスポート（内部ロジック変更なし）

## 追加テストの内訳

| ファイル | 対象 | ケース数 |
|---|---|---|
| `tests/util.test.ts` | `ReverseQueue` | 9 |
| `tests/graph/graphEdge.test.ts` | `GraphEdge.checkCrossed` / `checkNeighbor` | 12 |
| `tests/graph/graphNode.test.ts` | `GraphNode.getDist` / `getPos` / `setPos` | 6 |
| `tests/graph/graph.test.ts` | `Graph.culCntCrossedPoint` / `checkCrossedGraph` / `updateEdgeStatus` / `getClosestNode` | 15 |
| `tests/graph/delaunayUtils.test.ts` | `isCCW` / `inCircumcircle` / `uniqueBoundary` / `makeTri` / `bowyerWatson` | 14 |

## Test plan

- [x] `pnpm test` を実行して 56 テストがすべて PASS することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)